### PR TITLE
OSV-10321 : Upgrade guava version to 32.0.1-jre to resolve CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.0-jre</version>
+			<version>32.0.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
This patch was tested locally.